### PR TITLE
feat: enable autodetection of conventional commits

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,6 @@
     "dependencies"
   ],
   "branchPrefix": "dependencies/",
-  "commitMessagePrefix": "deps: ",
   "baseBranches": ["main"],
   "packageRules": [
     {


### PR DESCRIPTION
  * @see: https://docs.renovatebot.com/semantic-commits/
  * `chore(deps)` will be used by default